### PR TITLE
feat: bump mpv to 0.39.0 and update deps

### DIFF
--- a/libs/macos/media_kit_libs_macos_video/macos/Makefile
+++ b/libs/macos/media_kit_libs_macos_video/macos/Makefile
@@ -1,7 +1,7 @@
 all: Frameworks/*.xcframework Frameworks/.symlinks
 
-MPV_XCFRAMEWORKS_VERSION=v0.6.0
-MPV_XCFRAMEWORKS_SHA256SUM=84d2ad98e046e82c6dc34d8547d76c2afeaee89c0f53032773be8985c95536d6
+MPV_XCFRAMEWORKS_VERSION=v0.39.0
+MPV_XCFRAMEWORKS_SHA256SUM=aaff2180aab39cf3f4c75fe33f03fea38a12073411787777060207998f5e9047
 
 TAR=tar
 TAR_WILDCARDS_FLAG := $(shell ${TAR} --version 2>&1 | grep -q 'GNU' && echo "--wildcards" || echo "")
@@ -13,7 +13,7 @@ SED_INPLACE_FLAG := $(shell ${SED} --version 2>&1 | grep -q 'GNU' && echo "" || 
 	mkdir -p .cache/xcframeworks
 	rm -f .cache/xcframeworks/*.tmp .cache/xcframeworks/*-macos-universal.tar.gz
 	curl -L \
-		https://github.com/media-kit/libmpv-darwin-build/releases/download/${MPV_XCFRAMEWORKS_VERSION}/libmpv-xcframeworks_${MPV_XCFRAMEWORKS_VERSION}_macos-universal-video-default.tar.gz \
+		https://github.com/pancake-vn/media-kit/releases/download/${MPV_XCFRAMEWORKS_VERSION}/libmpv-xcframeworks_${MPV_XCFRAMEWORKS_VERSION}_macos-universal-video-default.tar.gz \
 		-o .cache/xcframeworks/libmpv.tar.gz.tmp
 	shasum -a 256 -c <<< '${MPV_XCFRAMEWORKS_SHA256SUM}  .cache/xcframeworks/libmpv.tar.gz.tmp'
 	mv .cache/xcframeworks/libmpv.tar.gz.tmp .cache/xcframeworks/libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-macos-universal.tar.gz

--- a/libs/macos/media_kit_libs_macos_video/pubspec.yaml
+++ b/libs/macos/media_kit_libs_macos_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_macos_video
 description: macOS package providing video (& audio) native libraries for package:media_kit.
-version: 1.1.4
+version: 1.1.5
 homepage: https://github.com/media-kit/media-kit.git
 repository: https://github.com/media-kit/media-kit.git
 

--- a/libs/universal/media_kit_libs_video/pubspec.yaml
+++ b/libs/universal/media_kit_libs_video/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   media_kit_libs_android_video: ^1.3.6
   media_kit_libs_ios_video: ^1.1.4
-  media_kit_libs_macos_video: ^1.1.4
+  media_kit_libs_macos_video:
+    path: ../../macos/media_kit_libs_macos_video
   media_kit_libs_windows_video: ^1.0.10
   media_kit_libs_linux: ^1.1.3


### PR DESCRIPTION
Currently media-kit uses `mpv 0.36.0`, which builds from [here](https://github.com/media-kit/libmpv-darwin-build/blob/6d78c22/packages.lock.nix#L77).
With `mpv 0.36.0`, some issue has been raised from Pancake Work macOS app like following:
- wrong duration of video
- cannot load some videos recorded from ios or screen

As I found that, issue actually comes from `mpv 0.36.0` instead of media-kit, I do following steps in this PR:
- I upgrade mpv to `0.39.0` with some dependencies. Also I release build for `mpv 0.39.0` [here](https://github.com/pancake-vn/media-kit/releases/tag/v0.39.0)
- I integrate libmpv to media-kit

### References
https://github.com/media-kit/libmpv-darwin-build/issues/39
https://github.com/gungun974/melodink-libmpv-darwin-build/blob/f7abbcbaf8154c2d3a044fcfddc437432a1aa05a/scripts/libplacebo/build.sh